### PR TITLE
Support multiple heading levels and improve TOC visibility

### DIFF
--- a/add-table-of-contents-to-basecamp.user.js
+++ b/add-table-of-contents-to-basecamp.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Add Table of Contents to Basecamp documents
 // @namespace    http://basecamp.com
-// @version      0.3
+// @version      0.4
 // @description  Add a table of contents at the top of Basecamp documents in a specific team
 // @author       Mathias Foster
 // @match        https://3.basecamp.com/*/buckets/*/documents/*
@@ -14,7 +14,8 @@
     'use strict';
     console.log("Userscript is working");
 
-    let scrape = document.querySelectorAll('.formatted_content > h1');
+    // Basecamp now offers three heading levels (formerly a single Title), so pick up all of them
+    let scrape = document.querySelectorAll('.formatted_content h1, .formatted_content h2, .formatted_content h3');
 
     // Target the main content instead of the header
     let content = document.querySelector('article');
@@ -37,7 +38,9 @@
     }
 
     for (let i = 0; i < scrape.length; i++) {
-        if (scrape[i].innerText) {
+        // Skip hidden headings, e.g. Basecamp's "isn't fully functional right now" warning
+        let isVisible = scrape[i].getClientRects().length > 0;
+        if (scrape[i].innerText.trim() && isVisible) {
             // Add id to heading
             scrape[i].setAttribute("id", "heading" + i.toString());
 
@@ -50,8 +53,10 @@
                 document.location.hash = "heading" + i.toString();
             });
 
-            // Create new list item
+            // Create new list item, indented to match the heading level (h1/h2/h3)
             let newLi = document.createElement('li');
+            let headingLevel = parseInt(scrape[i].tagName.substring(1), 10);
+            newLi.style.marginLeft = ((headingLevel - 1) * 20) + 'px';
             newA.appendChild(newLi);
 
             // Create text inside list item


### PR DESCRIPTION
## Summary
Enhanced the table of contents generation to support Basecamp's three heading levels (h1, h2, h3) instead of just h1, with improved handling of hidden elements and proper indentation based on heading hierarchy.

## Key Changes
- **Multi-level heading support**: Updated selector to capture h1, h2, and h3 elements instead of only h1
- **Hidden element filtering**: Added visibility check using `getClientRects()` to skip hidden headings (e.g., Basecamp's warning messages)
- **Hierarchical indentation**: Implemented margin-left styling on TOC list items to visually indent h2 and h3 entries relative to h1
- **Improved text handling**: Added `.trim()` to heading text check for more robust empty heading detection
- **Documentation**: Added clarifying comments explaining the changes

## Implementation Details
- Heading level is extracted from the tag name (h1/h2/h3) and used to calculate indentation (20px per level)
- Visibility detection prevents broken links in the TOC from hidden/warning elements
- Version bumped from 0.3 to 0.4

https://claude.ai/code/session_01916crZ6aMoFKfLdzNWBpJG